### PR TITLE
OS specific files should not appear in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 test
 npm-debug.log
-.DS_Store


### PR DESCRIPTION
`.DS_Store` is a file specific to OSX and should be moved to [a global .gitignore](https://murze.be/2014/12/create-a-global-gitignore/)

(btw: have you noticed that in Sierra `.DS_Store` just doesn't exist anymore? :-))