### PR TITLE
✨ added the possibilty to use flow

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -78,6 +78,7 @@ module.exports = generator.Base.extend({
 
     this.props = {
       yarn: true,
+      flow: false,
       license: `MIT`,
       year: new Date().getFullYear()
     };
@@ -138,6 +139,11 @@ module.exports = generator.Base.extend({
       type: `input`,
       name: `github`,
       message: `Github Username`,
+    }, {
+      type: `confirm`,
+      name: `flow`,
+      default: false,
+      message: `Do you need flow for type checking?`,
     }]).then(props => {
       this.props = Object.assign(this.props, props);
       this.props.ccname = this._camelCase(this.props.name);
@@ -194,6 +200,10 @@ module.exports = generator.Base.extend({
         `.travis.yml`
       ];
 
+      const flow = [
+        `.flowconfig`
+      ];
+
       const files = [
         ...eslint,
         ...git,
@@ -201,7 +211,8 @@ module.exports = generator.Base.extend({
         ...rollup,
         ...editor,
         ...npm,
-        ...ci
+        ...ci,
+        ...flow
       ];
 
       files.forEach(f => this._copyFile(f));

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -143,7 +143,7 @@ module.exports = generator.Base.extend({
       type: `confirm`,
       name: `flow`,
       default: false,
-      message: `Do you need flow for type checking?`,
+      message: `Do you need flow for type checking? (No)`,
     }]).then(props => {
       this.props = Object.assign(this.props, props);
       this.props.ccname = this._camelCase(this.props.name);
@@ -200,20 +200,27 @@ module.exports = generator.Base.extend({
         `.travis.yml`
       ];
 
-      const flow = [
-        `.flowconfig`
-      ];
-
-      const files = [
+      let files = [
         ...eslint,
         ...git,
         ...babel,
         ...rollup,
         ...editor,
         ...npm,
-        ...ci,
-        ...flow
+        ...ci
       ];
+
+      if (this.props.flow) {
+
+        const flow = [
+          `.flowconfig`
+        ];
+
+        files = [
+          ...files,
+          ...flow
+        ];
+      }
 
       files.forEach(f => this._copyFile(f));
 

--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -1,20 +1,19 @@
 {
+  <% if(flow) {%>"plugins": [
+    ["transform-flow-strip-types"]
+  ],<% } %>
   "env": {
     "cjs": {
       "presets": [
         ["es2015", {"loose": true}]
       ],
       "plugins": [
-        ["add-module-exports"],
-        <% if(flow) {%>["transform-flow-strip-types"]<% } %>
+        ["add-module-exports"]
       ]
     },
     "es": {
       "presets": [
         ["es2015", {"loose": true, "modules": false}]
-      ],
-      "plugins": [
-        <% if(flow) {%>["transform-flow-strip-types"]<% } %>
       ]
     }
   }

--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -5,12 +5,16 @@
         ["es2015", {"loose": true}]
       ],
       "plugins": [
-        "add-module-exports"
+        ["add-module-exports"],
+        <% if(flow) {%>["transform-flow-strip-types"]<% } %>
       ]
     },
     "es": {
       "presets": [
         ["es2015", {"loose": true, "modules": false}]
+      ],
+      "plugins": [
+        <% if(flow) {%>["transform-flow-strip-types"]<% } %>
       ]
     }
   }

--- a/generators/app/templates/.flowconfig
+++ b/generators/app/templates/.flowconfig
@@ -1,0 +1,8 @@
+[libs]
+./node_modules/fbjs/flow/lib
+
+[options]
+module.system.node.resolve_dirname=node_modules
+
+suppress_type=$FlowIssue
+suppress_type=$FlowFixMe

--- a/generators/app/templates/.flowconfig
+++ b/generators/app/templates/.flowconfig
@@ -5,7 +5,6 @@
 ./node_modules/fbjs/flow/lib
 
 [options]
-module.name_mapper='^\(.*\)$' -> '<PROJECT_ROOT>/\1'
 module.system.node.resolve_dirname=node_modules
 
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue

--- a/generators/app/templates/.flowconfig
+++ b/generators/app/templates/.flowconfig
@@ -1,8 +1,12 @@
+[ignore]
+.*/__tests__/.*
+
 [libs]
 ./node_modules/fbjs/flow/lib
 
 [options]
+module.name_mapper='^\(.*\)$' -> '<PROJECT_ROOT>/\1'
 module.system.node.resolve_dirname=node_modules
 
-suppress_type=$FlowIssue
-suppress_type=$FlowFixMe
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -60,11 +60,14 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    <% if(flow) { >"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
     "babel-preset-es2015": "^6.16.0",
     "cross-env": "^3.1.3",
     "eslint": "^3.7.1",
     "eslint-config-devine": "^1.5.0",
     "eslint-plugin-babel": "^3.3.0",
+    <% if(flow) { >"eslint-plugin-flowtype": "^2.25.0",<% } %>
+    <% if(flow) { >"flow-bin": "^0.35.0"<% } %>
     "jest": "^16.0.1",
     "rimraf": "^2.5.4",
     "release-it": "^2.5.1",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -35,7 +35,8 @@
 
     "release": "release-it",
 
-    "lint": "eslint src/*.js <% if (flow) {%>&& npm run lint:flow<% } %>",
+    "lint": "npm run lint:eslint<% if (flow) {%> && npm run lint:flow<% } %>",
+    "lint:eslint": "eslint src/*.js",
     <% if(flow) {%>"lint:flow": "flow --color always",<% } %>
     "lint:build": "npm run lint && npm run build:cjs -s",
     "lint:build:test": "npm run lint:build && npm run test:coverage",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -68,7 +68,6 @@
     "eslint": "^3.7.1",
     "eslint-config-devine": "^1.5.0",
     "eslint-plugin-babel": "^3.3.0",
-    <% if(flow) { %>"eslint-plugin-flowtype": "^2.25.0",<% } %>
     <% if(flow) { %>"flow-bin": "^0.35.0",<% } %>
     "jest": "^16.0.1",
     "rimraf": "^2.5.4",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -35,8 +35,8 @@
 
     "release": "release-it",
 
-    "lint": "eslint src/*.js <% if (flow) {%>&& lint:flow<% } %>",
-    <% if(flow) {%>"lint:flow": "flow --color always"<% } %>
+    "lint": "eslint src/*.js <% if (flow) {%>&& npm run lint:flow<% } %>",
+    <% if(flow) {%>"lint:flow": "flow --color always",<% } %>
     "lint:build": "npm run lint && npm run build:cjs -s",
     "lint:build:test": "npm run lint:build && npm run test:coverage",
 
@@ -61,14 +61,14 @@
     "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    <% if(flow) { >"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
+    <% if(flow) { %>"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
     "babel-preset-es2015": "^6.16.0",
     "cross-env": "^3.1.3",
     "eslint": "^3.7.1",
     "eslint-config-devine": "^1.5.0",
     "eslint-plugin-babel": "^3.3.0",
-    <% if(flow) { >"eslint-plugin-flowtype": "^2.25.0",<% } %>
-    <% if(flow) { >"flow-bin": "^0.35.0"<% } %>
+    <% if(flow) { %>"eslint-plugin-flowtype": "^2.25.0",<% } %>
+    <% if(flow) { %>"flow-bin": "^0.35.0",<% } %>
     "jest": "^16.0.1",
     "rimraf": "^2.5.4",
     "release-it": "^2.5.1",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -35,7 +35,8 @@
 
     "release": "release-it",
 
-    "lint": "eslint src/*.js",
+    "lint": "eslint src/*.js <% if (flow) {%>&& lint:flow<% } %>",
+    <% if(flow) {%>"lint:flow": "flow --color always"<% } %>
     "lint:build": "npm run lint && npm run build:cjs -s",
     "lint:build:test": "npm run lint:build && npm run test:coverage",
 


### PR DESCRIPTION
Feature addition for #13 
- [x] Defaults to false for initialising the generator
- [x] Introduces new files: `generators/app/templates/.flowconfig`
- [x] Introduces the flowtype plugin for eslint
- [x] Introduces a new npm run task `lint:flow` which will display colorised output.
- [x] Updates .babelrc to strip the flow comments out of the builds for es & cjs
- [x] Updates the `lint` task to check for eslint & flow errors
- [x] flowconfig
    * ignores `__tests__` by default (you can change this later if you want tests to use flow too)
    * uses the default lib from the node_module installation, you can add your own lib for your personally defined flowtypes 
    * resolves modules from `node_modules` and project root
    * Has support for `// FlowFixMe` and `// FlowIssue` comments in your code