### PR TITLE
💚 Use babel-eslint in conjunction to flow

### DIFF
--- a/generators/app/templates/.eslintrc
+++ b/generators/app/templates/.eslintrc
@@ -1,3 +1,11 @@
 {
-  "extends": "devine"
+  "parser": "babel-eslint",
+  "plugins": ["flowtype"],
+  "extends": [
+    "devine",
+    "plugin:flowtype/recommended"
+  ],
+  "settings": {
+    "flowtype": {"onlyFilesWithFlowAnnotation": true}
+  }
 }

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
+    <% if(flow) {"babel-eslint": "^7.1.1",<% } %>
     "babel-plugin-add-module-exports": "^0.2.1",
     <% if(flow) { %>"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
     "babel-preset-es2015": "^6.16.0",
@@ -68,7 +69,8 @@
     "eslint": "^3.7.1",
     "eslint-config-devine": "^1.5.0",
     "eslint-plugin-babel": "^3.3.0",
-    <% if(flow) { %>"flow-bin": "^0.35.0",<% } %>
+    <% if(flow) { %>"eslint-plugin-flowtype": "^2.29.1",
+    "flow-bin": "^0.35.0",<% } %>
     "jest": "^16.0.1",
     "rimraf": "^2.5.4",
     "release-it": "^2.5.1",


### PR DESCRIPTION
The build task would fail since it lints before testing. Eslint would error since it would not recognize the type annotations declared in flow-checked files. Switched to using babel-eslint as the parser and the flowtype plugin. This is not opinionated but actually required in the current scenario.