### PR TITLE
Added babel-jest for node v4 and v5

### DIFF
--- a/generators/app/templates/.babelrc
+++ b/generators/app/templates/.babelrc
@@ -3,6 +3,9 @@
     ["transform-flow-strip-types"]
   ],<% } %>
   "env": {
+    "test": {
+      "presets": ["es2015"]
+    },
     "cjs": {
       "presets": [
         ["es2015", {"loose": true}]

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -58,9 +58,13 @@
   "author": "<%= author %> (<%= email %>)",
   "license": "<%= license %>",
   "repository": "<%= github %>/<%= name %>",
+  "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
+    "babel-jest": "^18.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     <% if(flow) { %>"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
     "babel-preset-es2015": "^6.16.0",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -58,13 +58,9 @@
   "author": "<%= author %> (<%= email %>)",
   "license": "<%= license %>",
   "repository": "<%= github %>/<%= name %>",
-  "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
-  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.17.0",
-    "babel-jest": "^18.0.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     <% if(flow) { %>"babel-plugin-transform-flow-strip-types": "^6.18.0",<% } %>
     "babel-preset-es2015": "^6.16.0",


### PR DESCRIPTION
With the previous configuration it was impossible to write test using ES6 syntax and make 
the pass on node versions 4 and 5. This pr adds the required configurations to make jest
use babel as traspiler when running tests:

- Adds babel-jest as a dev dependency
- Adds babel-jest transpiler options
- Adds required babel presets for the test environment on `.babelrc`

To see an example of project generated using the changes proposed on this PR please check:
https://github.com/danielo515/generator-module-boilerplate-test-es6