### PR TITLE
:art: Restructured build, added test, rm clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 - **Project structure** to create a cross build npm module
 - **Linting**: via [ESLint](http://eslint.org/)
 - **Testing**: with Coverage via [Jest](https://facebook.github.io/jest/)
-- **[CommonJS](http://webpack.github.io/docs/commonjs.html)**: build (`/cjs`)  via [Babel](https://babeljs.io/)
-- **[ES2015](http://www.2ality.com/2014/09/es6-modules-final.html)**: build (`/es`) via [Babel](https://babeljs.io/)
-- **[UMD](https://github.com/umdjs/umd)** build: (`/dist`) via [Rollup](http://rollupjs.org/) (unminified & minified version)
+- **[CommonJS](http://webpack.github.io/docs/commonjs.html)**: build (`/dist/cjs`)  via [Babel](https://babeljs.io/)
+- **[ES2015](http://www.2ality.com/2014/09/es6-modules-final.html)**: build (`/dist/es`) via [Babel](https://babeljs.io/)
+- **[UMD](https://github.com/umdjs/umd)** build: (`/dist/umd`) via [Rollup](http://rollupjs.org/) (unminified & minified version)
 - **Watch scripts**: `npm run (test|build):watch`
 - **Git hooks**: precommit, prepush hooks defined in `package.json`
 - **prepublish** (before publishing to npm) script `npm run build`
@@ -72,7 +72,7 @@ Testing via [Jest](https://facebook.github.io/jest/) in [interactive watch mode]
 npm run test:watch
 ```
 
-**[CommonJS](http://webpack.github.io/docs/commonjs.html) build** (`/cjs`) via [Babel](https://babeljs.io/)
+**[CommonJS](http://webpack.github.io/docs/commonjs.html) build** (`/dist/cjs`) via [Babel](https://babeljs.io/)
 
 ```console
 npm run build:watch
@@ -90,8 +90,8 @@ The build command runs the following steps:
 
 1. **Linting** via [ESLint](http://eslint.org/) (+ optional [Flow](https://flowtype.org/) typechecking)
 3. **Testing** (with Coverage) via [Jest](https://facebook.github.io/jest/)
-4. **[CommonJS](http://webpack.github.io/docs/commonjs.html) build** (`/cjs`)  via [Babel](https://babeljs.io/)
-5. **[ES2015](http://www.2ality.com/2014/09/es6-modules-final.html) build** (`/es`) via [Babel](https://babeljs.io/)
+4. **[CommonJS](http://webpack.github.io/docs/commonjs.html) build** (`/dist/cjs`)  via [Babel](https://babeljs.io/)
+5. **[ES2015](http://www.2ality.com/2014/09/es6-modules-final.html) build** (`/dist/es`) via [Babel](https://babeljs.io/)
 6. **[UMD](https://github.com/umdjs/umd) builds** (`/dist`) via [Rollup](http://rollupjs.org/)
 
 which equals to:

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -11,14 +11,7 @@ const {
 
 const mkdir = require(`mkdirp`);
 
-let isFirstClear = true;
-
 module.exports = generator.Base.extend({
-
-  _clearConsole() {
-    process.stdout.write(isFirstClear ? `\x1bc` : `\x1b[2J\x1b[0f`);
-    isFirstClear = false;
-  },
 
   _getNPMConfig() {
     const author = exec(`npm config get init.author.name`, {encoding: `utf-8`}) || ``;
@@ -167,7 +160,8 @@ module.exports = generator.Base.extend({
 
       const files = [
         `example/script.js`,
-        `src/index.js`
+        `src/index.js`,
+        `__tests__/test.js`
       ];
 
       files.forEach(f => this._copyFile(f));
@@ -175,8 +169,6 @@ module.exports = generator.Base.extend({
     },
 
     settings() {
-
-      this._createDir(`__tests__`);
 
       const eslint = [
         `.eslintignore`,
@@ -261,8 +253,6 @@ module.exports = generator.Base.extend({
     spawn(`git`, [`commit`, `-m`, `${emoji}initial commit`], {stdio: `inherit`});
 
     if (this.props.yarn) this._spawn(`node node_modules/husky/bin/install`); // see husky readme.
-
-    this._clearConsole();
 
     init(this.props);
 

--- a/generators/app/templates/.eslintignore
+++ b/generators/app/templates/.eslintignore
@@ -1,4 +1,2 @@
-cjs
-es
 dist
 coverage

--- a/generators/app/templates/CONTRIBUTING.md
+++ b/generators/app/templates/CONTRIBUTING.md
@@ -34,7 +34,7 @@ In general, the contribution workflow looks like this:
 2. **Clone** the repo. `git clone https://github.com/your-username/<%= name %>.git`.
 3. Create a **new branch** based off the master branch, provide a **descriptive name** <br/>(ex. '**feat**-add-better-logging', '**bug**-removed-double-method', '**enh**-bumped-eslint')
 4. Before running the code you’ll need to **install** the **dependencies** (`npm install` or `yarn`).
-5. **Implement** your feature / bugfix (using the **watch scripts**), you should **only need to modify `/src`**. Don’t worry about regenerating the build folders (`/cjs`, `/es`, `/dist`), they are **built** in the **prepublish** phase.
+5. **Implement** your feature / bugfix (using the **watch scripts**), you should **only need to modify `/src`**. Don’t worry about regenerating the build folder `/dist`, it is **built** in the **prepublish** phase.
 6. Make sure **all tests pass**, **coverage is 100%** and there are **no linting errors**.
 7. Submit a **PR**, referencing what it addresses.
 8. Please try to keep your **PR focused in scope and avoid including unrelated commits**<% if (gitmoji) { %>, use **[Gitmoji](https://gitmoji.carloscuesta.me/)** in your commits<% } %>.
@@ -75,7 +75,7 @@ $ npm run lint
 
 ## Testing
 
-Include updated (or add new) tests in the `__tests__` directory as part of your PR.
+Include updated (or add new) tests in the `__tests__/` directory as part of your PR.
 
 You can **run the test script** by using
 

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -63,7 +63,7 @@ If you don't use a package manager, you can [access `<%= name %>` via unpkg (CDN
 `<%= name %>` is compiled as a collection of [CommonJS](http://webpack.github.io/docs/commonjs.html) modules & [ES2015 modules](http://www.2ality.com/2014/0
   -9/es6-modules-final.html) for bundlers that support the `jsnext:main` or `module` field in package.json (Rollup, Webpack 2)
 
-The `<%= name %>` package includes precompiled production and development [UMD](https://github.com/umdjs/umd) builds in the [`dist` folder](https://unpkg.com/<%= name %>/dist/). They can be used directly without a bundler and are thus compatible with many popular JavaScript module loaders and environments. You can drop a UMD build as a [`<script>` tag](https://unpkg.com/<%= name %>) on your page. The UMD builds make `<%= name %>` available as a `window.<%= ccname %>` global variable.
+The `<%= name %>` package includes precompiled production and development [UMD](https://github.com/umdjs/umd) builds in the [`dist/umd` folder](https://unpkg.com/<%= name %>/dist/umd/). They can be used directly without a bundler and are thus compatible with many popular JavaScript module loaders and environments. You can drop a UMD build as a [`<script>` tag](https://unpkg.com/<%= name %>) on your page. The UMD builds make `<%= name %>` available as a `window.<%= ccname %>` global variable.
 
 ### License
 

--- a/generators/app/templates/__tests__/test.js
+++ b/generators/app/templates/__tests__/test.js
@@ -1,4 +1,4 @@
-import { helloWorld } from '../src/index';
+import helloWorld from '../src/index';
 
 describe(`my first test`, () => {
 

--- a/generators/app/templates/__tests__/test.js
+++ b/generators/app/templates/__tests__/test.js
@@ -1,0 +1,10 @@
+import { helloWorld } from '../src/index';
+
+describe(`my first test`, () => {
+
+  it(`must say hello world`, () => {
+    const actual = helloWorld();
+    expect(actual).toBe(`hello world`);
+  });
+
+});

--- a/generators/app/templates/_gitignore
+++ b/generators/app/templates/_gitignore
@@ -1,5 +1,3 @@
-es
-cjs
 dist
 node_modules
 coverage

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -2,14 +2,12 @@
   "name": "<%= name %>",
   "version": "0.0.0",
   "description": "<%= description %>",
-  "main": "cjs/index.js",
-  "browser": "dist/<%= ccname %>.js",
-  "module": "es/index.js",
-  "jsxnext:main": "es/index.js",
+  "main": "dist/cjs/index.js",
+  "browser": "dist/umd/<%= ccname %>.js",
+  "module": "dist/es/index.js",
+  "jsxnext:main": "dist/es/index.js",
   "files": [
     "dist",
-    "cjs",
-    "es",
     "src"
   ],
   "engines": {
@@ -31,18 +29,18 @@
     "lint:flow": "flow --color always",<%
   } %>
 
-    "test": "clear && jest",
+    "test": "jest",
     "test:coverage": "jest --coverage ",
     "test:watch": "clear && jest --watch",
 
     "lint:test": "npm run lint && npm run test:coverage",
 
-    "build": "clear && npm run lint:test && npm run build:cjs && npm run build:es && npm run build:umd",
-    "build:watch": "clear && rimraf cjs && cross-env BABEL_ENV=cjs babel -w src --out-dir cjs",
+    "build": "npm run lint:test && npm run build:cjs && npm run build:es && npm run build:umd",
+    "build:watch": "clear && rimraf dist/cjs && cross-env BABEL_ENV=cjs babel -w src --out-dir dist/cjs",
 
-    "build:es": "rimraf es && cross-env BABEL_ENV=es babel src --out-dir es",
-    "build:cjs": "rimraf cjs && cross-env BABEL_ENV=cjs babel src --out-dir cjs",
-    "build:umd": "rimraf dist && cross-env BABEL_ENV=es rollup -c & cross-env BABEL_ENV=es NODE_ENV=production rollup -c"
+    "build:es": "rimraf dist/es && cross-env BABEL_ENV=es babel src --out-dir dist/es",
+    "build:cjs": "rimraf dist/cjs && cross-env BABEL_ENV=cjs babel src --out-dir dist/cjs",
+    "build:umd": "rimraf dist/umd && cross-env BABEL_ENV=es rollup -c & cross-env BABEL_ENV=es NODE_ENV=production rollup -c"
 
   },
   "keywords": [],

--- a/generators/app/templates/rollup.config.js
+++ b/generators/app/templates/rollup.config.js
@@ -24,7 +24,7 @@ if (isProd) plugins.push(uglify());
 export default {
   entry: `src/index.js`,
   plugins,
-  dest: `dist/${name}${isProd ? `.min` : ``}.js`,
+  dest: `dist/umd/${name}${isProd ? `.min` : ``}.js`,
   moduleName: name,
   format: `umd`
 };

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,3 +1,3 @@
-export default () => {
-  console.log(`hello module`);
-};
+export function helloWorld() {
+  return `hello world`;
+}

--- a/generators/app/templates/src/index.js
+++ b/generators/app/templates/src/index.js
@@ -1,3 +1,3 @@
-export function helloWorld() {
+export default () => {
   return `hello world`;
-}
+};


### PR DESCRIPTION
* Too many top level dirs caused too much initial
 confusion, so I moved all 3 build types into dist:
    dist/umd, dist/es, dist/cjs
* A default test will greatly help getting started
* Removed auto screen clear - screen clear is only good
  for watch-style commands, but not when doing intiial
  anything. It is good to print everything - gives
  everyone a secure feeling that they didn't miss anything.